### PR TITLE
Docker: run without seccomp (distorts benchmarks)

### DIFF
--- a/tools/src/services/docker.ts
+++ b/tools/src/services/docker.ts
@@ -8,7 +8,7 @@ export default class DockerService {
   }
 
   public runContainer(imageName: string): string {
-    const output = child_process.execSync(`docker run --rm ${imageName}`, {
+    const output = child_process.execSync(`docker run --security-opt seccomp=unconfined --rm ${imageName}`, {
       stdio: 'pipe'
     });
     return output.toString('utf8');


### PR DESCRIPTION
## Description

Disables seccomp when running docker.

For unknown reasons, running python under docker can be over 50% slower than native usage. This is a performance bug in docker, which has something to do with its use of seccomp. See https://pythonspeed.com/articles/docker-performance-overhead/
and the corresponding docker issue https://github.com/moby/moby/issues/41389 

The performance difference is clear - locally when running `make DIRECTORY=PrimePython`, on a linux system the performance of the `ssovtest` solution goes from **1998** passes to **4110**. It seems seccomp doesn't affect the usage of the external numpy library or compiled languages, but you *may* see a speed boost for some other interpreted languages with this fix.

### Other considerations

Should we disable seccomp if it's providing security? Well, if all code in this repo has been reviewed and verified, it should be absolutely fine (note all the containers are running as root user anyway, so we better hope this is the case).

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
